### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe jQuery plugin

### DIFF
--- a/SE_Project/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/SE_Project/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $.find(element).not(this.settings.ignore)[0];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/CalinMariusAlex/SE_Project/security/code-scanning/6](https://github.com/CalinMariusAlex/SE_Project/security/code-scanning/6)

To fix the problem, we need to ensure that any user input used in jQuery selectors is properly sanitized to prevent XSS vulnerabilities. Specifically, we should avoid using `$(element)` directly with user input and instead use safer methods like `jQuery.find` which interprets the input strictly as a CSS selector.

- Modify the `validationTargetFor` function to use `jQuery.find` instead of `$(element)`.
- Ensure that any user input used in constructing selectors is properly sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
