### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/SE_Project/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/SE_Project/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return $.find(selector)[0];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/CalinMariusAlex/SE_Project/security/code-scanning/5](https://github.com/CalinMariusAlex/SE_Project/security/code-scanning/5)

To fix the problem, we need to ensure that the `selector` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of the `jQuery` constructor, which ensures that the input is always interpreted as a CSS selector.

- Modify the `clean` function to use `jQuery.find` instead of `jQuery`.
- Ensure that the `selector` parameter is properly sanitized and validated before being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
